### PR TITLE
Bumped the infisical agent injector CLI image to latest

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -34,7 +34,7 @@ const (
 
 const (
 	InitContainerName            = "infisical-agent-init"
-	InitContainerImage           = "infisical/cli:0.41.3" // todo(daniel): we might want to make this configurable in the future
+	InitContainerImage           = "infisical/cli:latest" // todo(daniel): we might want to make this configurable in the future
 	InitContainerVolumeMountName = "infisical-init"
 	InitContainerVolumeMountPath = "/home/infisical"
 


### PR DESCRIPTION
To keep the CLI version that is used in the sidecar up to date, latest would fit. Currently, the 0.41.3 doesn't seem to support ARM architecture correctly. 